### PR TITLE
Add msc1 support for T31

### DIFF
--- a/boards.cfg
+++ b/boards.cfg
@@ -62,6 +62,7 @@ isvp_t30a1_sfcnor_ddr128M   mips   xburst   isvp_t30    ingenic   t30   isvp_t30
 
 isvp_t31_sfcnor             mips   xburst   isvp_t31    ingenic   t31   isvp_t31:SPL_SFC_SUPPORT,ENV_IS_IN_SPI_FLASH,SPL_SFC_NOR,JZ_MMC_MSC0
 isvp_t31_sfcnor_ddr128M     mips   xburst   isvp_t31    ingenic   t31   isvp_t31:SPL_SFC_SUPPORT,ENV_IS_IN_SPI_FLASH,SPL_SFC_NOR,JZ_MMC_MSC0,DDR2_128M
+isvp_t31_sfcnor_msc1_ddr128M mips  xburst   isvp_t31    ingenic   t31   isvp_t31:SPL_SFC_SUPPORT,ENV_IS_IN_SPI_FLASH,SPL_SFC_NOR,JZ_MMC_MSC0,JZ_MMC_MSC1,DDR2_128M
 isvp_t31_sfcnor_lite        mips   xburst   isvp_t31    ingenic   t31   isvp_t31:SPL_SFC_SUPPORT,ENV_IS_IN_SPI_FLASH,SPL_SFC_NOR,JZ_MMC_MSC0,LITE_VERSION
 isvp_t31a_sfcnor_ddr128M    mips   xburst   isvp_t31    ingenic   t31   isvp_t31:SPL_SFC_SUPPORT,ENV_IS_IN_SPI_FLASH,SPL_SFC_NOR,JZ_MMC_MSC0,DDR3_128M,T31A
 isvp_t31al_sfcnor_ddr128M   mips   xburst   isvp_t31    ingenic   t31   isvp_t31:SPL_SFC_SUPPORT,ENV_IS_IN_SPI_FLASH,SPL_SFC_NOR,JZ_MMC_MSC0,DDR2_128M,T31AL

--- a/build.sh
+++ b/build.sh
@@ -36,6 +36,7 @@ pick_a_soc() {
 		"isvp_t31lc_sfcnor"		"Ingenic T31LC"		\
 		"isvp_t31_sfcnor"		"Ingenic T31N"		\
 		"isvp_t31_sfcnor_ddr128M"	"Ingenic T31X"		\
+		"isvp_t31_sfcnor_msc1_ddr128M"	"Ingenic T31X  MSC1"	\
 		"isvp_t31a_sfcnor_ddr128M"	"Ingenic T31A"		\
 		"isvp_t31al_sfcnor_ddr128M"	"Ingenic T31AL"		\
 		"isvp_t31_msc0"			"Ingenic T31N  MSC0"	\

--- a/drivers/gpio/jz_gpio/t31_gpio.c
+++ b/drivers/gpio/jz_gpio/t31_gpio.c
@@ -19,6 +19,9 @@ static struct jz_gpio_func_def gpio_func[] = {
 #if defined(CONFIG_JZ_MMC_MSC0_PB)
 	{.port = GPIO_PORT_B, .func = GPIO_FUNC_0, .pins = (0x3 << 4 | 0xf << 0)},
 #endif
+#if defined(CONFIG_JZ_MMC_MSC1_PB)
+	{.port = GPIO_PORT_B, .func = GPIO_FUNC_1, .pins = (0x3 << 13|0xf << 8)},
+#endif
 #if defined(CONFIG_JZ_SFC_PA)
 	{.port = GPIO_PORT_A, .func = GPIO_FUNC_1, .pins = (0x3 << 23) | (0x3 << 27), .driver_strength = 4},
 #endif

--- a/include/configs/isvp_t31.h
+++ b/include/configs/isvp_t31.h
@@ -96,10 +96,16 @@
 #define CONFIG_JZ_MMC			1
 #endif  /* JZ_MMC_MSC0 || JZ_MMC_MSC1 */
 
+#if defined(CONFIG_JZ_MMC_MSC0) && defined(CONFIG_JZ_MMC_MSC1)
+#define CONFIG_JZ_MMC_SPLMSC		1
+#define CONFIG_JZ_MMC_MSC0_PB		1
+#define CONFIG_JZ_MMC_MSC1_PB		1
+#else
 #if defined(CONFIG_JZ_MMC_MSC0)
 #define CONFIG_JZ_MMC_SPLMSC		0
 #define CONFIG_JZ_MMC_MSC0_PB		1
 #endif
+#endif /* JZ_MMC_MSC0 && JZ_MMC_MSC1 */
 
 /*
 #if defined(CONFIG_SFC_COMMAND)


### PR DESCRIPTION
Add MSC1 defines for T31.
If the wlan board is connected to SDIO on MSC1, it will not work without this patch.
I created a new SoC model "Ingenic T31X MSC1" and a new target "isvp_t31_sfcnor_msc1_ddr128M".
